### PR TITLE
fix infer faiss params

### DIFF
--- a/server/voice_changer/RVC/pipeline/Pipeline.py
+++ b/server/voice_changer/RVC/pipeline/Pipeline.py
@@ -146,11 +146,16 @@ class Pipeline(object):
             # D, I = self.index.search(npy, 1)
             # npy = self.feature[I.squeeze()]
 
-            score, ix = self.index.search(npy, k=8)
-            weight = np.square(1 / score)
-            weight /= weight.sum(axis=1, keepdims=True)
-
-            npy = np.sum(self.big_npy[ix] * np.expand_dims(weight, axis=2), axis=1)
+            # TODO: kは調整できるようにする
+            k = 1
+            if k == 1:
+                _, ix = self.index.search(npy, 1)
+                npy = self.big_npy[ix.squeeze()]               
+            else:
+                score, ix = self.index.search(npy, k=8)
+                weight = np.square(1 / score)
+                weight /= weight.sum(axis=1, keepdims=True)
+                npy = np.sum(self.big_npy[ix] * np.expand_dims(weight, axis=2), axis=1)
 
             if self.isHalf is True:
                 npy = npy.astype("float16")


### PR DESCRIPTION
WSL2 + Anacondaで動かせました～

ここのパラメータについては、faissのパラメータを決めていた時に
n_probe = XにしてX個のクラスタを決めるよりも、上位X個の類似度の加重平均をとった方がよりknnの結果に近づくという実験をしたところ、採用されたパラメータでした。
ただ、実際のところ、knnの結果に対してある程度の誤差があっても十分に推論することはでき、計算時間ほどのパフォーマンスが得られないことがわかってきました。

計算時間短縮のため、k=1に固定していずれ余裕のある時にoptionとして追加してもいいのでは？くらいの感覚です。

WSL2動かせたテストとしてPR作成します。