### PR TITLE
protect + crepe対応

### DIFF
--- a/server/voice_changer/RVC/ModelSlot.py
+++ b/server/voice_changer/RVC/ModelSlot.py
@@ -12,6 +12,7 @@ class ModelSlot:
     indexFile: str = ""
     defaultTune: int = 0
     defaultIndexRatio: int = 1
+    # defaultProtect: float = .5
     isONNX: bool = False
     modelType: EnumInferenceTypes = EnumInferenceTypes.pyTorchRVC
     samplingRate: int = -1

--- a/server/voice_changer/RVC/ModelSlotGenerator.py
+++ b/server/voice_changer/RVC/ModelSlotGenerator.py
@@ -36,6 +36,9 @@ def generateModelSlot(slotDir: str):
         modelSlot.defaultIndexRatio = (
             params["defaultIndexRatio"] if "defaultIndexRatio" in params else 0
         )
+        # modelSlot.defaultProtect = (
+        #     params["defaultProtect"] if "defaultProtect" in params else 0.5
+        # )
         modelSlot.name = params["name"] if "name" in params else None
         modelSlot.description = params["description"] if "description" in params else None
         modelSlot.credit = params["credit"] if "credit" in params else None

--- a/server/voice_changer/RVC/RVC.py
+++ b/server/voice_changer/RVC/RVC.py
@@ -242,6 +242,7 @@ class RVC:
         # その他の設定
         self.next_trans = modelSlot.defaultTune
         self.next_index_ratio = modelSlot.defaultIndexRatio
+        # self.next_protect = modelSlot.defaultProtect
         self.next_samplingRate = modelSlot.samplingRate
         self.next_framework = "ONNX" if modelSlot.isONNX else "PyTorch"
         # self.needSwitch = True
@@ -254,6 +255,7 @@ class RVC:
         self.pipeline = self.next_pipeline
         self.settings.tran = self.next_trans
         self.settings.indexRatio = self.next_index_ratio
+        # self.settings.protect = self.next_protect
         self.settings.modelSamplingRate = self.next_samplingRate
         self.settings.framework = self.next_framework
 
@@ -336,6 +338,7 @@ class RVC:
         sid = 0
         f0_up_key = self.settings.tran
         index_rate = self.settings.indexRatio
+        protect = .5# self.settings.protect
         if_f0 = 1 if self.settings.modelSlots[self.currentSlot].f0 else 0
         embOutputLayer = self.settings.modelSlots[self.currentSlot].embOutputLayer
         useFinalProj = self.settings.modelSlots[self.currentSlot].useFinalProj
@@ -350,6 +353,7 @@ class RVC:
             embOutputLayer,
             useFinalProj,
             repeat,
+            protect
         )
 
         result = audio_out.detach().cpu().numpy() * np.sqrt(vol)
@@ -411,6 +415,7 @@ class RVC:
         params = {
             "defaultTune": req.defaultTune,
             "defaultIndexRatio": req.defaultIndexRatio,
+            # "defaultProtect": req.defaultProtect
             "sampleId": "",
             "files": {"rvcModel": storeFile},
         }
@@ -432,6 +437,7 @@ class RVC:
         )
         params["defaultTune"] = self.settings.tran
         params["defaultIndexRatio"] = self.settings.indexRatio
+        # params["defaultProtect"] = self.settings.protect
 
         json.dump(params, open(os.path.join(slotDir, "params.json"), "w"))
         self.loadSlots()

--- a/server/voice_changer/RVC/RVCSettings.py
+++ b/server/voice_changer/RVC/RVCSettings.py
@@ -29,6 +29,7 @@ class RVCSettings:
     sampleModels: list[RVCModelSample] = field(default_factory=lambda: [])
 
     indexRatio: float = 0
+    # protect: float = 0.5
     rvcQuality: int = 0
     silenceFront: int = 1  # 0:off, 1:on
     modelSamplingRate: int = 48000
@@ -50,5 +51,5 @@ class RVCSettings:
         "isHalf",
         "enableDirectML",
     ]
-    floatData = ["silentThreshold", "indexRatio"]
+    floatData = ["silentThreshold", "indexRatio"]  # , "protect"]
     strData = ["framework", "f0Detector"]

--- a/server/voice_changer/RVC/SampleDownloader.py
+++ b/server/voice_changer/RVC/SampleDownloader.py
@@ -81,6 +81,7 @@ def downloadInitialSampleModels(sampleJsons: list[str], model_dir: str):
         sampleParams["sampleId"] = sample.id
         sampleParams["defaultTune"] = 0
         sampleParams["defaultIndexRatio"] = 1
+        # sampleParams["defaultProtect"] = 0.5
         sampleParams["credit"] = sample.credit
         sampleParams["description"] = sample.description
         sampleParams["name"] = sample.name

--- a/server/voice_changer/RVC/modelMerger/MergeModelRequest.py
+++ b/server/voice_changer/RVC/modelMerger/MergeModelRequest.py
@@ -17,4 +17,5 @@ class MergeModelRequest:
     slot: int = -1
     defaultTune: int = 0
     defaultIndexRatio: int = 1
+    # defaultProtect: float = .5
     files: List[MergeFile] = field(default_factory=lambda: [])


### PR DESCRIPTION
protectについて追加しました。protect=0.5でオフにしていますが、手動でprotect=.33にして動くのを確認しています。
また、crepeについても修正し、f0の推定がうまくいかないとき他のf0推定機同様0を返すよう変更しました。

serverの関係しそうな部分をindexRatioと同様に変更したのですが実行時にエラーが起きたので、コメントアウトしています。現在この状態では動いているので、clientの部分は修正をお願いします。
