### PR TITLE
GITHUB: Added FAQ and re-work on Issues Template

### DIFF
--- a/.github/FAQ.md
+++ b/.github/FAQ.md
@@ -1,8 +1,15 @@
 # Frequently Asked Questions
 Please read this FAQ before asking or making a bug report.
 
+### General fixes:
+*Do all these steps so you can fix some issues.*
+- Restart the application
+- Go to your Windows %AppData% (Win + R, then put %appdata% and press Enter) and delete the "**voice-changer-native-client**" folder
+- Extract your .zip to a new location and avoid folders with space or specials characters (also avoid long file paths)
+- If you don't have a GPU or have a too old GPU, try using the [Colab Version](https://colab.research.google.com/github/w-okada/voice-changer/blob/master/Realtime_Voice_Changer_on_Colab.ipynb) instead
+
 ### 1. AMD GPU don't appear or not working
-> Please download the **latest DirectML version**, use the **f0 det. rmvpe_onnx** and .ONNX models only! (.pth models do not work properly, use the "Export to ONNX" if you have a .pth model)
+> Please download the **latest DirectML version**, use the **f0 det. rmvpe_onnx** and .ONNX models only! (.pth models do not work properly, use the "Export to ONNX" it can take a while)
 
 ### 2. NVidia GPU don't appear or not working
 > Make sure that the [NVidia CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) drivers are installed on your PC and up-to-date
@@ -10,8 +17,8 @@ Please read this FAQ before asking or making a bug report.
 ### 3. High CPU usage
 > Decrease your EXTRA value and put the index feature to 0
 
-### 4. High Latency/Reponse
+### 4. High Latency
 > Decrease your chunk value until you find a good mix of quality and response time
 
-### 5. I'm hearing my voice without changes!
+### 5. I'm hearing my voice without changes
 > Make sure to disable **passthru** mode

--- a/.github/FAQ.md
+++ b/.github/FAQ.md
@@ -1,0 +1,17 @@
+# Frequently Asked Questions
+Please read this FAQ before asking or making a bug report.
+
+### 1. AMD GPU don't appear or not working
+> Please download the **latest DirectML version**, use the **f0 det. rmvpe_onnx** and .ONNX models only! (.pth models do not work properly, use the "Export to ONNX" if you have a .pth model)
+
+### 2. NVidia GPU don't appear or not working
+> Make sure that the [NVidia CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) drivers are installed on your PC and up-to-date
+
+### 3. High CPU usage
+> Decrease your EXTRA value and put the index feature to 0
+
+### 4. High Latency/Reponse
+> Decrease your chunk value until you find a good mix of quality and response time
+
+### 5. I'm hearing my voice without changes!
+> Make sure to disable **passthru** mode

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Do you have some feature request? Use this template
+title: "[REQUEST]: "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -5,8 +5,18 @@ body:
   - type: markdown
     attributes:
       value: When creating a feature request, please be aware that <b>we do not guarantee that your idea will be implemented. We are always working to make our software better, so please be pacient and do not put pressure on our devs.
+  - type: input
+    id: few-words
+    attributes:
+      label: In a few words, describe your idea
+      description: With a few words, briefly describe your idea
+      placeholder: ex. My idea is to implement rmvpe!
+    validations:
+      required: true
   - type: textarea
     id: request
     attributes:
-      label: Describe your idea
-      description: Please provide enough information so we can understand and implement your idea
+      label: More information
+      description: If you have a complex idea, please use this field to describe it more, please provide enough information so we can understand and implement your idea
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,9 +1,9 @@
-name: Request
+name: Feature Request
 description: Do you have some feature request? Use this template
 body:
   - type: markdown
     attributes:
-      value: When creating a feature request, please be aware that we do not guarantee that your idea will be implemented. We are always working to make our software better, so please be pacient and do not put pressure on our devs.
+      value: When creating a feature request, please be aware that <b>we do not guarantee that your idea will be implemented. We are always working to make our software better, so please be pacient and do not put pressure on our devs.
   - type: textarea
     id: request
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,11 @@
+name: Request
+description: Do you have some feature request? Use this template
+body:
+  - type: markdown
+    attributes:
+      value: When creating a feature request, please be aware that we do not guarantee that your idea will be implemented. We are always working to make our software better, so please be pacient and do not put pressure on our devs.
+  - type: textarea
+    id: request
+    attributes:
+      label: Describe your idea
+      description: Please provide enough information so we can understand and implement your idea

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -4,7 +4,7 @@ title: "[REQUEST]: "
 body:
   - type: markdown
     attributes:
-      value: When creating a feature request, please be aware that <b>we do not guarantee that your idea will be implemented. We are always working to make our software better, so please be pacient and do not put pressure on our devs.
+      value: When creating a feature request, please be aware that **we do not guarantee that your idea will be implemented**. We are always working to make our software better, so please be pacient and do not put pressure on our devs.
   - type: input
     id: few-words
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -42,8 +42,8 @@ body:
   - type: input
     id: vc-type
     attributes:
-      label: Voice Changer type
-      description: Which type of voice changer you use? e.g. MMVC v1.3, RVC
+      label: Model Type
+      description: MMVC, so-vits-rvc, RVC, DDSP-SVC
       placeholder: RVC
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -47,23 +47,16 @@ body:
       placeholder: RVC
     validations:
       required: true
-  - type: input
-    id: model-type
-    attributes:
-      label: Model Type
-      description: List up the type of model you use? e.g. pyTorch, ONNX, f0, no f0
-    validations:
-      required: true
   - type: textarea
     id: issue
     attributes:
-      label: Situation
-      description: Developers spend a lot of time developing new features and resolving issues. If you really want to get it solved, please provide as much reproducible information and logs as possible. Provide logs on the terminal and capture the appkication window.
+      label: Issue Description
+      description: Please provide as much reproducible information and logs as possible
   - type: textarea
     id: capture
     attributes:
       label: Application Screenshot
-      description: Please provide a screenshot of your application so we can see your settings
+      description: Please provide a screenshot of your application so we can see your settings (you can paste or drag-n-drop)
   - type: textarea
     id: logs-on-terminal
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -2,6 +2,10 @@ name: Issue
 description: Please provide as much detail as possible to convey the history of your problem.
 title: "[ISSUE]: "
 body:
+  - type: markdown
+    attributes:
+      value: ### Please read our [FAQ](https://github.com/w-okada/voice-changer/blob/master/.github/FAQ.md) before making a bug report!
+  
   - type: input
     id: vc-client-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -31,7 +31,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
-      label: Checks 
+      label: Read carefully and check the options
       options:
         - label: I've tried to Clear Settings
         - label: Sample/Default Models are working 

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -31,18 +31,12 @@ body:
     id: checks
     attributes:
       options:
-        - label: I've tried to clear settings
-          description: Check if you have pressed "Clear Settings" and restarted application
-        - label: Sample models are working
-          description: Check if default models are working properly
+        - label: I've tried to Clear Settings
+        - label: Sample/Default Models are working 
         - label: I've tried to change the Chunk Size
-          description: Check this if you tried to decrease/increase your chunk size
         - label: GUI was successfully launched
-          description: Check this if you can see the GUI
-        - label: I've read the tutorial
-          description: Check if you have read the [tutorial](https://github.com/w-okada/voice-changer/blob/master/tutorials/tutorial_rvc_en_latest.md)
-        - label: I've tried to extract to another folder (or re-extracted)
-          description: Check if you have tried another folder and re-extracted the files
+        - label: I've read the [tutorial](https://github.com/w-okada/voice-changer/blob/master/tutorials/tutorial_rvc_en_latest.md)
+        - label: I've tried to extract to another folder (or re-extract) the .zip file
   - type: input
     id: vc-type
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -5,7 +5,6 @@ body:
   - type: markdown
     attributes:
       value: ### Please read our [FAQ](https://github.com/w-okada/voice-changer/blob/master/.github/FAQ.md) before making a bug report!
-  
   - type: input
     id: vc-client-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -1,18 +1,6 @@
 name: Issue
 description: Please provide as much detail as possible to convey the history of your problem.
 body:
-  - type: dropdown
-    id: issue-type
-    attributes:
-      label: Issue Type
-      description: What type of issue would you like to report?
-      multiple: true
-      options:
-        - Documentation Feature Request
-        - Bug Report
-        - Others
-    validations:
-      required: true
   - type: input
     id: vc-client-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -4,7 +4,8 @@ title: "[ISSUE]: "
 body:
   - type: markdown
     attributes:
-      value: ### Please read our [FAQ](https://github.com/w-okada/voice-changer/blob/master/.github/FAQ.md) before making a bug report!
+      value: |
+      # Please read our [FAQ](https://github.com/w-okada/voice-changer/blob/master/.github/FAQ.md) before making a bug report!
   - type: input
     id: vc-client-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -4,8 +4,7 @@ title: "[ISSUE]: "
 body:
   - type: markdown
     attributes:
-      value: |
-      # Please read our [FAQ](https://github.com/w-okada/voice-changer/blob/master/.github/FAQ.md) before making a bug report!
+      value: Please read our [FAQ](https://github.com/w-okada/voice-changer/blob/master/.github/FAQ.md) before making a bug report!
   - type: input
     id: vc-client-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -30,7 +30,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
-      label: | 
+      label: Checks 
       options:
         - label: I've tried to Clear Settings
         - label: Sample/Default Models are working 

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -30,6 +30,7 @@ body:
   - type: checkboxes
     id: checks
     attributes:
+      label: | 
       options:
         - label: I've tried to Clear Settings
         - label: Sample/Default Models are working 

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -8,7 +8,6 @@ body:
       description: What type of issue would you like to report?
       multiple: true
       options:
-        - Feature Request
         - Documentation Feature Request
         - Bug Report
         - Question

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -1,5 +1,6 @@
 name: Issue
 description: Please provide as much detail as possible to convey the history of your problem.
+title: "[ISSUE]: "
 body:
   - type: input
     id: vc-client-version

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -10,14 +10,15 @@ body:
     attributes:
       label: Voice Changer Version
       description: Downloaded File Name (.zip)
-      placeholder: e.g. MMVCServerSIO_xxx_yyyy-zzzz_v.x.x.x.x.zip
+      placeholder: MMVCServerSIO_xxx_yyyy-zzzz_v.x.x.x.x.zip
     validations:
       required: true
   - type: input
     id: OS
     attributes:
-      label: OS
-      description: OS name and version. e.g. Windows 10, Ubuntu 20.04, if you use mac, M1 or Intel.(Intel is not supported) and version venture, monterey, big sur.
+      label: Operational System
+      description: e.g. Windows 10, Ubuntu 20.04, MacOS Venture, MacOS Monterey, etc...
+      placeholder: Windows 10
     validations:
       required: true
   - type: input
@@ -49,7 +50,7 @@ body:
   - type: input
     id: model-type
     attributes:
-      label: Model type
+      label: Model Type
       description: List up the type of model you use? e.g. pyTorch, ONNX, f0, no f0
     validations:
       required: true
@@ -61,12 +62,12 @@ body:
   - type: textarea
     id: capture
     attributes:
-      label: application window capture
-      description: the appkication window.
+      label: Application Screenshot
+      description: Please provide a screenshot of your application so we can see your settings
   - type: textarea
     id: logs-on-terminal
     attributes:
-      label: logs on terminal
-      description: logs on terminal.
+      label: Logs on console
+      description: Copy and paste the log on your console here
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -1,4 +1,4 @@
-name: Issue
+name: Issue or Bug Report
 description: Please provide as much detail as possible to convey the history of your problem.
 title: "[ISSUE]: "
 body:

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -10,7 +10,6 @@ body:
       options:
         - Documentation Feature Request
         - Bug Report
-        - Question
         - Others
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/issue.yaml
+++ b/.github/ISSUE_TEMPLATE/issue.yaml
@@ -8,9 +8,9 @@ body:
   - type: input
     id: vc-client-version
     attributes:
-      label: vc client version number
-      description: filename of you download(.zip)
-      placeholder: MMVCServerSIO_xxx_yyyy-zzzz_v.x.x.x.x.zip
+      label: Voice Changer Version
+      description: Downloaded File Name (.zip)
+      placeholder: e.g. MMVCServerSIO_xxx_yyyy-zzzz_v.x.x.x.x.zip
     validations:
       required: true
   - type: input
@@ -24,70 +24,25 @@ body:
     id: GPU
     attributes:
       label: GPU
-      description: GPU. If you have no gpu, please input none.
+      description: If you have no gpu, please input none.
     validations:
       required: true
-  - type: dropdown
-    id: clear-setting
+  - type: checkboxes
+    id: checks
     attributes:
-      label: Clear setting
-      description: Have you tried clear setting?
       options:
-        - "no"
-        - "yes"
-    validations:
-      required: true
-  - type: dropdown
-    id: sample-model
-    attributes:
-      label: Sample model
-      description: Sample model work fine
-      options:
-        - "no"
-        - "yes"
-    validations:
-      required: true
-  - type: dropdown
-    id: input-chunk-num
-    attributes:
-      label: Input chunk num
-      description: Have you tried to change input chunk num?
-      options:
-        - "no"
-        - "yes"
-    validations:
-      required: true
-  - type: dropdown
-    id: wait-for-launch
-    attributes:
-      label: Wait for a while
-      description: If the GUI won't start up, wait a several minutes. Alternatively, have you excluded it from your virus-checking software (at your own risk)?
-      options:
-        - "The GUI successfully launched."
-        - "no"
-        - "yes"
-    validations:
-      required: true
-  - type: dropdown
-    id: read-tutorial
-    attributes:
-      label: read tutorial
-      description: Have you read the tutorial? https://github.com/w-okada/voice-changer/blob/master/tutorials/tutorial_rvc_en_latest.md
-      options:
-        - "no"
-        - "yes"
-    validations:
-      required: true
-  - type: dropdown
-    id: extract-to-new-folder
-    attributes:
-      label: Extract files to a new folder.
-      description: Extract files from a zip file to a new folder, different from the previous version.(If you have.)
-      options:
-        - "no"
-        - "yes"
-    validations:
-      required: true
+        - label: I've tried to clear settings
+          description: Check if you have pressed "Clear Settings" and restarted application
+        - label: Sample models are working
+          description: Check if default models are working properly
+        - label: I've tried to change the Chunk Size
+          description: Check this if you tried to decrease/increase your chunk size
+        - label: GUI was successfully launched
+          description: Check this if you can see the GUI
+        - label: I've read the tutorial
+          description: Check if you have read the [tutorial](https://github.com/w-okada/voice-changer/blob/master/tutorials/tutorial_rvc_en_latest.md)
+        - label: I've tried to extract to another folder (or re-extracted)
+          description: Check if you have tried another folder and re-extracted the files
   - type: input
     id: vc-type
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,6 +1,5 @@
-name: Question | Others
+name: Question or Other
 description: Do you any question? Use this template
-title: "[QUESTION]: "
 body:
   - type: markdown
     attributes:
@@ -8,7 +7,7 @@ body:
   - type: textarea
     id: question  
     attributes:
-      label: My Question
-      description: What is your question?
+      label: Description
+      description: What is your question? (or other non-related to bugs/feature-request)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,4 +1,4 @@
-name: Question
+name: Question | Others
 description: Do you any question? Use this template
 title: "[QUESTION]: "
 body:

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,14 @@
+name: Question
+description: Do you any question? Use this template
+title: "[QUESTION]: "
+body:
+  - type: markdown
+    attributes:
+      value: We are always working to make our software better, so please be pacient and wait for a response
+  - type: textarea
+    id: question  
+    attributes:
+      label: My Question
+      description: What is your question?
+    validations:
+      required: true


### PR DESCRIPTION
I've tried to make it easier to understand the issue template both when posting and when reading an issue. I've reduced the Issue Template using checks instead of drops and added different templates for feature request and questions (since it don't need specific information that need on bug reporting)

Please check my fork and see if you like the template style before merging. 
https://github.com/Rafacasari/voice-changer

FAQ are available here (mentioned in bug report template): https://github.com/Rafacasari/voice-changer/blob/master/.github/FAQ.md