### PR TITLE
Added CUDA 12.8 support for RTX 5000 series

### DIFF
--- a/README_dev_en.md
+++ b/README_dev_en.md
@@ -20,15 +20,35 @@ $ conda activate vcclient-dev
 
 ```
 $ git clone https://github.com/w-okada/voice-changer.git
+$ cd voice-changer
 ```
 
 ## For Server Developer
 
 1. Install requirements
 
+1-1. For No GPU
+
 ```
-$ cd voice-changer/server
-$ pip install -r requirements.txt
+$ python -m pip install -r server/requirements_cpuonly.txt
+```
+
+1-2. For NVIDIA GPUs
+
+Please rewrite the `cu128` part in `server/requirements_nvidia.txt` according to your CUDA version.
+The default `cu128` is for CUDA 12.8.
+
+```
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+torch==2.7.0+cu128
+torchaudio==2.7.0+cu128
+```
+
+Next, execute the following:
+
+```
+$ python -m pip install -r server/requirements_nvidia.txt
 ```
 
 2. Run server
@@ -36,6 +56,7 @@ $ pip install -r requirements.txt
 Run server with the below command. You can replace the path to each weight.
 
 ```
+$ cd server
 $ python3 MMVCServerSIO.py -p 18888 --https true \
     --content_vec_500 pretrain/checkpoint_best_legacy_500.pt  \
     --content_vec_500_onnx pretrain/content_vec_500.onnx \

--- a/README_dev_ja.md
+++ b/README_dev_ja.md
@@ -20,15 +20,35 @@ $ conda activate vcclient-dev
 
 ```
 $ git clone https://github.com/w-okada/voice-changer.git
+$ cd voice-changer
 ```
 
 ## サーバ開発者向け
 
 1. モジュールをインストールする
 
+1-1. GPUなしの場合
+
 ```
-$ cd voice-changer/server
-$ pip install -r requirements.txt
+$ python -m pip install -r server/requirements_cpuonly.txt
+```
+
+1-2. NVIDIAのGPUを利用する場合
+
+server/requirements_nvidia.txtをCUDAのバージョンに応じて以下のcu128の部分を適宜書き換えてください。
+デフォルトのcu128場合はCUDA12.8向けです。
+
+```
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+torch==2.7.0+cu128
+torchaudio==2.7.0+cu128
+```
+
+次に以下を実行します
+
+```
+$ python -m pip install -r server/requirements_nvidia.txt
 ```
 
 2. サーバを起動する
@@ -36,6 +56,7 @@ $ pip install -r requirements.txt
 次のコマンドで起動します。各種重みについてのパスは環境に合わせて変えてください。
 
 ```
+$ cd server
 $ python3 MMVCServerSIO.py -p 18888 --https true \
     --content_vec_500 pretrain/checkpoint_best_legacy_500.pt  \
     --content_vec_500_onnx pretrain/content_vec_500.onnx \

--- a/README_dev_ko.md
+++ b/README_dev_ko.md
@@ -26,9 +26,28 @@ $ git clone https://github.com/w-okada/voice-changer.git
 
 1. 모듈을 설치한다
 
+1-1. GPU가 없는 경우
+
 ```
-$ cd voice-changer/server
-$ pip install -r requirements.txt
+$ python -m pip install -r server/requirements_cpuonly.txt
+```
+
+1-2. NVIDIA GPU를 사용하는 경우
+
+`server/requirements_nvidia.txt` 파일에서 CUDA 버전에 따라 아래 `cu128` 부분을 적절히 수정하십시오.
+기본 `cu128`은 CUDA 12.8용입니다.
+
+```
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+torch==2.7.0+cu128
+torchaudio==2.7.0+cu128
+```
+
+다음을 실행하십시오:
+
+```
+$ python -m pip install -r server/requirements_nvidia.txt
 ```
 
 2. 서버를 구동한다

--- a/README_dev_ru.md
+++ b/README_dev_ru.md
@@ -28,9 +28,28 @@ $ git clone https://github.com/w-okada/voice-changer.git
 
 1. Установите необходимые зависимости:
 
+1-1. Для систем без GPU
+
 ```
-$ cd voice-changer/server
-$ pip install -r requirements.txt
+$ python -m pip install -r server/requirements_cpuonly.txt
+```
+
+1-2. Для систем с GPU NVIDIA
+
+Пожалуйста, перепишите часть `cu128` в файле `server/requirements_nvidia.txt` в соответствии с вашей версией CUDA.
+Значение по умолчанию `cu128` предназначено для CUDA 12.8.
+
+```
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+torch==2.7.0+cu128
+torchaudio==2.7.0+cu128
+```
+
+Затем выполните следующую команду:
+
+```
+$ python -m pip install -r server/requirements_nvidia.txt
 ```
 
 2. Запустите сервер

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,28 +3,29 @@
 # # wget https://repo.anaconda.com/archive/Anaconda3-2022.10-Linux-x86_64.sh
 # # bash Anaconda3-2022.10-Linux-x86_64.sh
 
-uvicorn==0.21.1
-pyOpenSSL==23.1.1
-numpy==1.23.5
-torch==2.0.1
-torchaudio==2.0.2
-resampy==0.4.2
-python-socketio==5.8.0
-fastapi==0.95.1
-python-multipart==0.0.6
-onnxruntime-gpu==1.13.1
-scipy==1.10.1
-matplotlib==3.7.1
-websockets==11.0.2
-faiss-cpu==1.7.3
-torchcrepe==0.0.18
-librosa==0.9.1
+# fairseq
+git+https://github.com/mallocfree009/fairseq.git@dev_mf1
+
+uvicorn==0.34.2
+pyOpenSSL==25.0.0
+numpy==2.1.2
+resampy==0.4.3
+python-socketio==5.13.0
+fastapi==0.115.12
+python-multipart==0.0.20
+onnxruntime-gpu==1.22.0
+scipy==1.15.3
+matplotlib==3.10.3
+websockets==15.0.1
+faiss-cpu==1.11.0
+torchcrepe==0.0.23
+librosa==0.11.0
 gin==0.1.6
-gin_config==0.5.0
-einops==0.6.0
-local_attention==1.8.5
-websockets==11.0.2
-sounddevice==0.4.6
-dataclasses_json==0.5.7
-onnxsim==0.4.28
-torchfcpe==0.0.3
+gin-config==0.5.0
+einops==0.8.1
+local-attention==1.11.1
+sounddevice==0.5.1
+dataclasses-json==0.6.7
+onnxsim==0.4.36
+torchfcpe==0.0.4
+pyworld==0.3.5

--- a/server/requirements_cpuonly.txt
+++ b/server/requirements_cpuonly.txt
@@ -1,0 +1,4 @@
+torch==2.7.0
+torchaudio==2.7.0
+
+-r requirements.txt

--- a/server/requirements_nvidia.txt
+++ b/server/requirements_nvidia.txt
@@ -1,0 +1,12 @@
+# As of 2025/05/17, if you do not install typing-extensions first, 
+# an error will occur when installing torch for NVIDIA.
+typing-extensions==4.13.2
+
+# Please set the URL and package version according to your CUDA version environment. 
+# The one listed here is for CUDA 12.8.
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+torch==2.7.0+cu128
+torchaudio==2.7.0+cu128
+
+-r requirements.txt


### PR DESCRIPTION
voice-changerにお世話になっております。mallocfree009です。

RTX5000シリーズで動作ができなかったので、いくつか必要な対応をいれてある程度うごくところまでもっていってみました。
ご多忙の中恐縮ですが、ご都合のよいときにプルリクの採用をご検討いただけるかご検討いただければ幸いです。

## 実装・動作確認環境

- OS: Windows11 23H2
- CPU: Ryzen 7 5700X
- GPU: NVIDIA GeForce RTX 5060 Ti or RTX 3070
- CUDA Toolkit 12.8
- cuDNN 9.8.0
- venv環境:
  作成方法: py -3.10 -m venv venv
  Python: 3.10.11
  pip: 23.0.1

## 実装後確認内容

変更後動作確認した内容は以下です。

- server側の起動で、ブラウザアクセスした状態で以下を確認
  - GPU/CPU環境でマイクから音声変換してスピーカー出力することを確認
  - GPU環境でRVCv2のpth,indexファイルをアップロードして、そのボイスを使い、マイクから音声変換してスピーカー出力することを確認
  - そのRVCv2ボイスをonnxに変換し、再度アップロードし、そのボイスでマイクから音声変換してスピーカー出力することを確認

###

RTX5000シリーズはCUDA12.8以降でないと動作せずtorchを2.7.0+cu128以降にアップする必要があり、torchのアップデートとそれに関連するパッケージについても調整を入れる必要がありました。

プルリクを採用するにあたっては、以下のようなプロジェクトの方針を鑑みて確認・調整すべき項目があります

- fairseqの更新が止まっておりtorch2.6.0以降には対応できてない問題への対処の調整
- requirements.txtの運用方法の変更についてのご確認

### fairseqの更新が止まっておりtorch2.6.0以降には対応できてない問題への対処の調整

fairseqは以前の依存関係ではrequirements.txtに指定されていませんでしたが、別途明記しないと利用できなくなりました。
そのため明記して追加するようにしましたがpipのデフォルトのリポジトリからインストールされるfairseqの最新バージョンでは下記エラーがでて正常に動作させることができません。

```
2025-05-02 13:06:16 | WARNING | infer.modules.vc.modules | Traceback (most recent call last):
  File "V:\ai\voice-changer\infer\modules\vc\modules.py", line 170, in vc_single
    self.hubert_model = load_hubert(self.config)
  File "V:\ai\voice-changer\infer\modules\vc\utils.py", line 23, in load_hubert
    models, _, _ = checkpoint_utils.load_model_ensemble_and_task(
  File "V:\ai\voice-changer\runtime\lib\site-packages\fairseq\checkpoint_utils.py", line 425, in load_model_ensemble_and_task
    state = load_checkpoint_to_cpu(filename, arg_overrides)
  File "V:\ai\voice-changer\runtime\lib\site-packages\fairseq\checkpoint_utils.py", line 315, in load_checkpoint_to_cpu
    state = torch.load(f, map_location=torch.device("cpu"))
  File "V:\ai\voice-changer\runtime\lib\site-packages\torch\serialization.py", line 1524, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
        WeightsUnpickler error: Unsupported global: GLOBAL fairseq.data.dictionary.Dictionary was not an allowed global by default. Please use `torch.serialization.add_safe_globals([fairseq.data.dictionary.Dictionary])` or the `torch.serialization.safe_globals([fairseq.data.dictionary.Dictionary])` context manager to allowlist this global if you trust this class/function.
```

PyTorch 2.6からの変更の影響で、これまでどおりの挙動をさせるにはfairseqパッケージ内のtorch.load()に引数weights_only=Falseを明示的に指定するよう修正する必要がありました。

このエラーについてはruntime\lib\site-packages\fairseq\checkpoint_utils.py(316)付近を以下のように書き換えると問題なくなりました。
```
    with open(local_path, "rb") as f:
        # state = torch.load(f, map_location=torch.device("cpu")) #MallocFree
        state = torch.load(f, map_location=torch.device("cpu"), weights_only=False) #MallocFree
```

ただfairseqは開発が停止しておりフルスクラッチで作り直したfairseq2が開発・推奨されています。
fairseq2にすると影響が大きいと思われるので一旦fairseqを私のGitHubのアカウントでフォークして、そこのtorch.load()について
修正を行い、そちらを参照してインストールするようにしています。

この状態で問題なく動作はしているようにみえます。

ただこのままだと例えば私がユーザーに危険が及ぶような変更をgitリポジトリに加えた場合(そんなことをするつもりは全くありませんが・・・)に、ユーザーに悪い影響がでてしまうのでgithubのリポジトリをw-okadaさんのGitHubアカウントでフォークして利用するように変更して、安全な状態を確保するほうがプロジェクトの運営上は安全かと思います。

プルリクの採用をご検討の場合は、どのような方針でfairseqを扱うかご決定いただければと思います。

## requirements.txtの運用方法の変更についてのご確認

requirements.txtのバージョン更新のための整理を行うことが今回の対応の主な作業となりましたが、torchがCPUのみの運用であるか、どのGPUか、CUDAバージョンは何かにより適切なものをインストールする必要がある観点から、分割するほうが良いかとおもい変更しています。

開発時の運用がかわるので合わせてドキュメントも調整してみました。

これはどういった運用が理想的か価値観の違いにより判断が変わるかと思います。
この運用ではなく、他の運用のほうがいいなどある場合がありますので適宜調整いただく必要あるかと思います。


ご多忙の中恐縮ですが、ご都合のよいときにご検討いただければ幸いです。






